### PR TITLE
Set width and height to 1 for hidden input

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -14,8 +14,8 @@ const styles = StyleSheet.create({
     width: getScreenWidth(),
   },
   hiddenTextInput: {
-    width: 0,
-    height: 0,
+    width: 1,
+    height: 1,
     backgroundColor: 'transparent',
   },
 });


### PR DESCRIPTION
The input is broken on Android devices. You can not type into an input which has no layout. This change set the input with and height to 1.